### PR TITLE
Reserved 256M of RAM for the EC2 host

### DIFF
--- a/deployment/cluster_template_generator.py
+++ b/deployment/cluster_template_generator.py
@@ -489,7 +489,7 @@ for cluster for 15 minutes.',
                 commands={
                     '01_add_instance_to_cluster': {
                         'command': Sub(
-                            'echo ECS_CLUSTER=${Cluster} > /etc/ecs/ecs.config'
+                            'echo "ECS_CLUSTER=${Cluster}\nECS_RESERVED_MEMORY=256" > /etc/ecs/ecs.config'
                         )
                     }
                 }

--- a/version/__init__.py
+++ b/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.1.1'
+VERSION = '1.1.2'


### PR DESCRIPTION
Before this, the running tasks could consume all the available memory and starve the host processes of memory.