### PR TITLE
Tasks have IAM Roles to allow access to other AWS services

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ six==1.10.0
 stringcase==1.0.6
 terminaltables==3.1.0
 troposphere>=2.4.1
+awacs==0.9.6

--- a/version/__init__.py
+++ b/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.1.1'
+VERSION = '1.1.2'


### PR DESCRIPTION
Create/Update of service, will create a service specific role and
attach it to every task via the task definition. By default, the role
has no permissions.