### PR TITLE
Remove parameter store validation

### DIFF
--- a/config/parameter_store.py
+++ b/config/parameter_store.py
@@ -87,14 +87,10 @@ class ParameterStore(object):
             if parameter_change[0] == 'change':
                 if not self._is_a_valid_parameter_key(parameter_change[1]):
                     errors.append("'%s' is not a valid key." % parameter_change[1])
-                if not self._is_a_valid_parameter_value(parameter_change[2][1]):
-                    errors.append("'%s' is not a valid value for key '%s'" % (parameter_change[2][1],parameter_change[1]))
             elif parameter_change[0] == 'add':
                 for added_parameter in parameter_change[2]:
                     if not self._is_a_valid_parameter_key(added_parameter[0]):
                         errors.append("'%s' is not a valid key." % added_parameter[0])
-                    if not self._is_a_valid_parameter_value(added_parameter[1]):
-                        errors.append("'%s' is not a valid value for key '%s'" % (added_parameter[1],added_parameter[0]))
             elif parameter_change[0] == 'remove':
                 # No validation required
                 pass
@@ -107,5 +103,3 @@ class ParameterStore(object):
     def _is_a_valid_parameter_key(self, key):
         return bool(re.match(r"^[\w|\.|\-|\/]+$", key))
 
-    def _is_a_valid_parameter_value(self, value):
-        return bool(re.match(r"^[\w|\.|\-|\/]+$", value))

--- a/test/templates/expected_service_template.yml
+++ b/test/templates/expected_service_template.yml
@@ -1,7 +1,7 @@
 Outputs:
   CloudliftOptions:
     Description: Options used with cloudlift when building this service
-    Value: '{"cloudlift_version": "1.1.3", "services": {"Dummy": {"memory_reservation": 1000, "command": null, "http_interface": {"internal": false, "container_port": 7003, "restrict_access_to": ["0.0.0.0/0"]}}, "DummyRunSidekiqsh": {"memory_reservation": 1000, "command": "./run-sidekiq.sh"}}}'
+    Value: '{"cloudlift_version": "1.1.4", "services": {"Dummy": {"memory_reservation": 1000, "command": null, "http_interface": {"internal": false, "container_port": 7003, "restrict_access_to": ["0.0.0.0/0"]}}, "DummyRunSidekiqsh": {"memory_reservation": 1000, "command": "./run-sidekiq.sh"}}}'
   DummyEcsServiceName:
     Description: 'The ECS name which needs to be entered'
     Value: !GetAtt 'Dummy.Name'

--- a/version/__init__.py
+++ b/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.1.3'
+VERSION = '1.1.4'


### PR DESCRIPTION
Now relying on AWS Parameter store to complain about violations.
Maintaining our own whitelist was becoming too much work.