### PR TITLE
TLS 1.0 and 1.1 are slated for deprecation

### DIFF
--- a/deployment/service_template_generator.py
+++ b/deployment/service_template_generator.py
@@ -350,7 +350,8 @@ service is down',
             DefaultActions=[target_group_action],
             LoadBalancerArn=Ref(alb),
             Port=443,
-            Certificates=[ssl_cert]
+            Certificates=[ssl_cert],
+            SslPolicy="ELBSecurityPolicy-FS-1-2-Res-2019-08"
         )
         self.template.add_resource(service_listener)
         if internal:

--- a/test/templates/expected_service_template.yml
+++ b/test/templates/expected_service_template.yml
@@ -1,7 +1,7 @@
 Outputs:
   CloudliftOptions:
     Description: Options used with cloudlift when building this service
-    Value: '{"cloudlift_version": "1.1.4", "services": {"Dummy": {"memory_reservation": 1000, "command": null, "http_interface": {"internal": false, "container_port": 7003, "restrict_access_to": ["0.0.0.0/0"]}}, "DummyRunSidekiqsh": {"memory_reservation": 1000, "command": "./run-sidekiq.sh"}}}'
+    Value: '{"cloudlift_version": "1.1.5", "services": {"Dummy": {"memory_reservation": 1000, "command": null, "http_interface": {"internal": false, "container_port": 7003, "restrict_access_to": ["0.0.0.0/0"]}}, "DummyRunSidekiqsh": {"memory_reservation": 1000, "command": "./run-sidekiq.sh"}}}'
   DummyEcsServiceName:
     Description: 'The ECS name which needs to be entered'
     Value: !GetAtt 'Dummy.Name'
@@ -372,6 +372,7 @@ Resources:
       LoadBalancerArn: !Ref 'ALBDummy'
       Port: 443
       Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-FS-1-2-Res-2019-08
     Type: AWS::ElasticLoadBalancingV2::Listener
   TargetGroupDummy:
     Properties:

--- a/version/__init__.py
+++ b/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.1.4'
+VERSION = '1.1.5'


### PR DESCRIPTION
https://arstechnica.com/gadgets/2018/10/browser-vendors-unite-to-end-support-for-20-year-old-tls-1-0/