### PR TITLE
Tasks have IAM Roles to allow access to other AWS services

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ six==1.10.0
 stringcase==1.0.6
 terminaltables==3.1.0
 troposphere>=2.4.1
+awacs==0.9.6

--- a/test/templates/expected_service_template.yml
+++ b/test/templates/expected_service_template.yml
@@ -1,7 +1,7 @@
 Outputs:
   CloudliftOptions:
     Description: Options used with cloudlift when building this service
-    Value: '{"cloudlift_version": "1.2.3", "services": {"Dummy": {"memory_reservation": 1000, "command": null, "http_interface": {"internal": false, "container_port": 7003, "restrict_access_to": ["0.0.0.0/0"], "health_check_path": "/elb-check"}}, "DummyRunSidekiqsh": {"memory_reservation": 1000, "command": "./run-sidekiq.sh"}}}'
+    Value: '{"cloudlift_version": "1.3.0", "services": {"Dummy": {"memory_reservation": 1000, "command": null, "http_interface": {"internal": false, "container_port": 7003, "restrict_access_to": ["0.0.0.0/0"]}}, "DummyRunSidekiqsh": {"memory_reservation": 1000, "command": "./run-sidekiq.sh"}}}'
   DummyEcsServiceName:
     Description: 'The ECS name which needs to be entered'
     Value: !GetAtt 'Dummy.Name'
@@ -78,6 +78,17 @@ Resources:
       Role: !Ref 'ECSServiceRole'
       TaskDefinition: !Ref 'DummyTaskDefinition'
     Type: AWS::ECS::Service
+  DummyRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+    Type: AWS::IAM::Role
   DummyRunSidekiqsh:
     Properties:
       Cluster: cluster-staging
@@ -92,6 +103,17 @@ Resources:
           Type: spread
       TaskDefinition: !Ref 'DummyRunSidekiqshTaskDefinition'
     Type: AWS::ECS::Service
+  DummyRunSidekiqshRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+    Type: AWS::IAM::Role
   DummyRunSidekiqshTaskDefinition:
     Properties:
       ContainerDefinitions:
@@ -112,6 +134,7 @@ Resources:
           MemoryReservation: 1000
           Name: DummyRunSidekiqshContainer
       Family: DummyRunSidekiqshFamily
+      TaskRoleArn: !Ref 'DummyRunSidekiqshRole'
     Type: AWS::ECS::TaskDefinition
   DummyTaskDefinition:
     Properties:
@@ -133,6 +156,7 @@ Resources:
           PortMappings:
             - ContainerPort: 7003
       Family: DummyFamily
+      TaskRoleArn: !Ref 'DummyRole'
     Type: AWS::ECS::TaskDefinition
   ECSServiceRole:
     Properties:
@@ -372,7 +396,6 @@ Resources:
       LoadBalancerArn: !Ref 'ALBDummy'
       Port: 443
       Protocol: HTTPS
-      SslPolicy: ELBSecurityPolicy-FS-1-2-Res-2019-08
     Type: AWS::ElasticLoadBalancingV2::Listener
   TargetGroupDummy:
     Properties:

--- a/version/__init__.py
+++ b/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.2.3'
+VERSION = '1.3.0'


### PR DESCRIPTION
Create/Update of service, will create a service specific role and
attach it to every task via the task definition. By default, the role
has no permissions.