### PR TITLE
Added explicit environment to role

### DIFF
--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -184,7 +184,7 @@ service is down',
         cd = ContainerDefinition(**container_definition_arguments)
 
         task_role = self.template.add_resource(Role(
-            service_name + "Role",
+            self.env + service_name + "Role",
             AssumeRolePolicyDocument=PolicyDocument(
                 Statement=[
                     Statement(

--- a/cloudlift/version/__init__.py
+++ b/cloudlift/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.4.3'
+VERSION = '1.4.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3>=1.9.89
+boto3>=1.13.1
 awscli
 certifi==2017.7.27.1
 cfn-flip==1.0.3

--- a/test/templates/expected_fargate_service_template.yml
+++ b/test/templates/expected_fargate_service_template.yml
@@ -1,7 +1,7 @@
 Outputs:
   CloudliftOptions:
     Description: Options used with cloudlift when building this service
-    Value: '{"cloudlift_version": "1.4.3", "services": {"DummyFargateRunSidekiqsh": {"command": null, "fargate": {"cpu": 256, "memory": 512}, "memory_reservation": 512}, "DummyFargateService": {"command": null, "fargate": {"cpu": 256, "memory": 512}, "http_interface": {"container_port": 80, "internal": false, "restrict_access_to": ["0.0.0.0/0"], "health_check_path": "/elb-check"}, "memory_reservation": 512}}}'
+    Value: '{"cloudlift_version": "1.4.4", "services": {"DummyFargateRunSidekiqsh": {"command": null, "fargate": {"cpu": 256, "memory": 512}, "memory_reservation": 512}, "DummyFargateService": {"command": null, "fargate": {"cpu": 256, "memory": 512}, "http_interface": {"container_port": 80, "internal": false, "restrict_access_to": ["0.0.0.0/0"], "health_check_path": "/elb-check"}, "memory_reservation": 512}}}'
   DummyFargateRunSidekiqshEcsServiceName:
     Description: The ECS name which needs to be entered
     Value: !GetAtt 'DummyFargateRunSidekiqsh.Name'
@@ -78,17 +78,6 @@ Resources:
             - !Ref 'PrivateSubnet2'
       TaskDefinition: !Ref 'DummyFargateRunSidekiqshTaskDefinition'
     Type: AWS::ECS::Service
-  DummyFargateRunSidekiqshRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action:
-              - sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - ecs-tasks.amazonaws.com
-    Type: AWS::IAM::Role
   DummyFargateRunSidekiqshTaskDefinition:
     Properties:
       ContainerDefinitions:
@@ -113,7 +102,7 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
-      TaskRoleArn: !Ref 'DummyFargateRunSidekiqshRole'
+      TaskRoleArn: !Ref 'stagingDummyFargateRunSidekiqshRole'
     Type: AWS::ECS::TaskDefinition
   DummyFargateService:
     DependsOn: SslLoadBalancerListenerDummyFargateService
@@ -134,17 +123,6 @@ Resources:
             - !Ref 'PrivateSubnet2'
       TaskDefinition: !Ref 'DummyFargateServiceTaskDefinition'
     Type: AWS::ECS::Service
-  DummyFargateServiceRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action:
-              - sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - ecs-tasks.amazonaws.com
-    Type: AWS::IAM::Role
   DummyFargateServiceTaskDefinition:
     Properties:
       ContainerDefinitions:
@@ -171,7 +149,7 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
-      TaskRoleArn: !Ref 'DummyFargateServiceRole'
+      TaskRoleArn: !Ref 'stagingDummyFargateServiceRole'
     Type: AWS::ECS::TaskDefinition
   ECSServiceRole:
     Properties:
@@ -448,3 +426,25 @@ Resources:
       UnhealthyThresholdCount: 3
       VpcId: !Ref 'VPC'
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
+  stagingDummyFargateRunSidekiqshRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+    Type: AWS::IAM::Role
+  stagingDummyFargateServiceRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+    Type: AWS::IAM::Role

--- a/test/templates/expected_service_template.yml
+++ b/test/templates/expected_service_template.yml
@@ -1,7 +1,7 @@
 Outputs:
   CloudliftOptions:
     Description: Options used with cloudlift when building this service
-    Value: '{"cloudlift_version": "1.4.3", "services": {"Dummy": {"memory_reservation": 1000, "command": null, "http_interface": {"internal": false, "container_port": 7003, "restrict_access_to": ["0.0.0.0/0"], "health_check_path": "/elb-check"}}, "DummyRunSidekiqsh": {"memory_reservation": 1000, "command": "./run-sidekiq.sh"}}}'
+    Value: '{"cloudlift_version": "1.4.4", "services": {"Dummy": {"memory_reservation": 1000, "command": null, "http_interface": {"internal": false, "container_port": 7003, "restrict_access_to": ["0.0.0.0/0"], "health_check_path": "/elb-check"}}, "DummyRunSidekiqsh": {"memory_reservation": 1000, "command": "./run-sidekiq.sh"}}}'
   DummyEcsServiceName:
     Description: 'The ECS name which needs to be entered'
     Value: !GetAtt 'Dummy.Name'
@@ -65,7 +65,7 @@ Resources:
     DependsOn: SslLoadBalancerListenerDummy
     Properties:
       Cluster: cluster-staging
-      DesiredCount: 1
+      DesiredCount: 0
       LaunchType: 'EC2'
       LoadBalancers:
         - ContainerName: DummyContainer
@@ -79,17 +79,6 @@ Resources:
       Role: !Ref 'ECSServiceRole'
       TaskDefinition: !Ref 'DummyTaskDefinition'
     Type: AWS::ECS::Service
-  DummyRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action:
-              - sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - ecs-tasks.amazonaws.com
-    Type: AWS::IAM::Role
   DummyRunSidekiqsh:
     Properties:
       Cluster: cluster-staging
@@ -105,17 +94,6 @@ Resources:
           Type: spread
       TaskDefinition: !Ref 'DummyRunSidekiqshTaskDefinition'
     Type: AWS::ECS::Service
-  DummyRunSidekiqshRole:
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action:
-              - sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - ecs-tasks.amazonaws.com
-    Type: AWS::IAM::Role
   DummyRunSidekiqshTaskDefinition:
     Properties:
       ContainerDefinitions:
@@ -136,7 +114,7 @@ Resources:
           MemoryReservation: 1000
           Name: DummyRunSidekiqshContainer
       Family: DummyRunSidekiqshFamily
-      TaskRoleArn: !Ref 'DummyRunSidekiqshRole'
+      TaskRoleArn: !Ref 'stagingDummyRunSidekiqshRole'
     Type: AWS::ECS::TaskDefinition
   DummyTaskDefinition:
     Properties:
@@ -158,7 +136,7 @@ Resources:
           PortMappings:
             - ContainerPort: 7003
       Family: DummyFamily
-      TaskRoleArn: !Ref 'DummyRole'
+      TaskRoleArn: !Ref 'stagingDummyRole'
     Type: AWS::ECS::TaskDefinition
   ECSServiceRole:
     Properties:
@@ -416,3 +394,25 @@ Resources:
       UnhealthyThresholdCount: 3
       VpcId: !Ref 'VPC'
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
+  stagingDummyRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+    Type: AWS::IAM::Role
+  stagingDummyRunSidekiqshRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+    Type: AWS::IAM::Role

--- a/test/test_cloudlift.py
+++ b/test/test_cloudlift.py
@@ -45,7 +45,7 @@ def mocked_fargate_service_config(cls, *args, **kwargs):
 
 environment_name = 'staging'
 service_name = 'dummy'
-fargate_service_name = 'dummy-fargate'
+fargate_service_name = f'{service_name}-fargate'
 
 def test_cloudlift_can_deploy_to_ec2(keep_resources):
     cfn_client = boto3.client('cloudformation')


### PR DESCRIPTION
This will ensure clarity when looking for the roles in AWS. While
cloudformation would prefix the environment, it would get truncated,
if the service name were too long.

Also bumped the boto3 version to ensure that some of the new
capabilities such as ECR image scanning work on all deployments.