### PR TITLE
Add ability to specify stop_timeout

### DIFF
--- a/cloudlift/config/service_configuration.py
+++ b/cloudlift/config/service_configuration.py
@@ -195,6 +195,9 @@ class ServiceConfiguration(object):
                         {"type": "string"},
                         {"type": "null"}
                     ]
+                },
+                "stop_timeout": {
+                    "type": "number"
                 }
             },
             "required": ["memory_reservation", "command"]

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -178,6 +178,9 @@ service is down',
                 )
             ]
 
+        if 'stop_timeout' in config:
+            container_definition_arguments['StopTimeout'] = int(config['stop_timeout'])
+
         if config['command'] is not None:
             container_definition_arguments['Command'] = [config['command']]
 

--- a/cloudlift/version/__init__.py
+++ b/cloudlift/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.4.3'
+VERSION = '1.5.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ requests>=2.20.0
 six==1.10.0
 stringcase==1.0.6
 terminaltables==3.1.0
-troposphere>=2.4.1
+troposphere>=2.4.7
 awacs==0.9.6

--- a/test/config/service_configuration_test.py
+++ b/test/config/service_configuration_test.py
@@ -113,3 +113,30 @@ class TestServiceConfiguration(object):
                         }
                     }
                 }
+
+
+    @mock_dynamodb2
+    def test_set_config_stop_timeout(self):
+        self.setup_existing_params()
+
+        store_object = ServiceConfiguration('test-service', 'dummy-staging')
+        get_response = store_object.get_config()
+
+        get_response["services"]["TestService"]["stop_timeout"] = 120
+        store_object.set_config(get_response)
+        update_response = store_object.get_config()
+
+        assert update_response == {
+                    "services": {
+                        "TestService": {
+                            "memory_reservation": 1000,
+                            "command": None,
+                            "http_interface": {
+                                "internal": True,
+                                "container_port": 80,
+                                "restrict_access_to": [u'0.0.0.0/0']
+                            },
+                            "stop_timeout": 120
+                        }
+                    }
+                }


### PR DESCRIPTION
Changes:
- Add support in Service definition to specifiy `stop_timeout` which will be added as `stopTimeout` in `containerDefinitions`
- Bump up the minimum Troposphere version  that supports the specification