### PR TITLE
Support for AWS ELBv2 NLBs

### DIFF
--- a/cloudlift/deployment/cluster_template_generator.py
+++ b/cloudlift/deployment/cluster_template_generator.py
@@ -627,6 +627,11 @@ for cluster for 15 minutes.',
             Value=Ref('SecurityGroupAlb'))
         )
         self.template.add_output(Output(
+            "SecurityGroupEc2Hosts",
+            Description="Security group ID for ECS Hosts",
+            Value=Ref('SecurityGroupEc2Hosts'))
+        )
+        self.template.add_output(Output(
             "MinInstances",
             Description="Minimum instances in cluster",
             Value=str(self.configuration['cluster']['min_instances']))

--- a/test/blackjack/.dockerignore
+++ b/test/blackjack/.dockerignore
@@ -1,0 +1,2 @@
+*
+!entrypoint.sh

--- a/test/blackjack/Dockerfile
+++ b/test/blackjack/Dockerfile
@@ -1,0 +1,25 @@
+FROM buildpack-deps
+
+
+# update distribution
+RUN apt-get update      \
+ && apt-get upgrade -y  \
+ && rm -rf /var/lib/apt/lists/*
+
+# Debugging utilities
+RUN apt-get update            \
+ && apt-get install -y socat  \
+ && rm -rf /var/lib/apt/lists/*
+
+# Debugging utilities
+RUN apt-get update          \
+ && apt-get install -y vim  \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 1025/udp
+EXPOSE 1026/tcp
+
+COPY entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD []

--- a/test/blackjack/Makefile
+++ b/test/blackjack/Makefile
@@ -1,0 +1,15 @@
+SHELL=/bin/bash
+
+build:
+	docker build -t blackjack .
+
+start:
+	docker run -it --rm --init --name blackjack -p 1025:1025/udp -p 1026:1026/tcp blackjack
+
+test:
+	echo "deal" | socat - udp:localhost:1025
+	echo "game" | socat - tcp:localhost:1026
+	socat /dev/null TCP:localhost:1026
+
+stop:
+	docker stop blackjack

--- a/test/blackjack/README.md
+++ b/test/blackjack/README.md
@@ -1,0 +1,177 @@
+## Purpose
+TCP/UDP (IPv4 only) echo test service.
+
+Why "blackjack" ?
+* port 1025 IANA registry - `network blackjack 1025`
+  * https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?&page=16
+
+## Config
+```json
+{
+    "services": {
+        "Blackjack": {
+            "command": null,
+            "udp_interface": {
+                "container_port": 1025,
+                "internal": false,
+                "restrict_access_to": [
+                    "0.0.0.0/0"
+                ]
+            },
+            "memory_reservation": 1000
+        }
+    }
+}
+```
+
+## Development
+server: `NOTE - careful quoting required`
+```bash
+test/blackjack$ socat -v udp4-l:1025,reuseaddr,fork system:"sed -ur -e \'s/^/no /\'"
+```
+
+client:
+```bash
+test/blackjack$ echo "deal" | socat - udp:localhost:1025
+```
+
+## Test
+```bash
+# Build/Rebuild image
+test/blackjack$ make
+
+# Run foreground server (terminal 1)
+test/blackjack$ make start
+
+# Run simulated client (terminal 2)
+test/blackjack$ make test
+```
+
+## Links
+* https://hub.docker.com/_/buildpack-deps/
+  * https://github.com/docker-library/buildpack-deps/blob/master/debian/buster/Dockerfile
+
+## Reference
+Online help: http://www.dest-unreach.org/socat/doc/socat.html
+
+Usage:
+```
+$ socat -h
+socat by Gerhard Rieger - see www.dest-unreach.org
+
+Usage:
+socat [options] <bi-address> <bi-address>
+   options:
+      -V     print version and feature information to stdout, and exit
+      -h|-?  print a help text describing command line options and addresses
+      -hh    like -h, plus a list of all common address option names
+      -hhh   like -hh, plus a list of all available address option names
+      -d     increase verbosity (use up to 4 times; 2 are recommended)
+      -D     analyze file descriptors before loop
+      -ly[facility]  log to syslog, using facility (default is daemon)
+      -lf<logfile>   log to file
+      -ls            log to stderr (default if no other log)
+      -lm[facility]  mixed log mode (stderr during initialization, then syslog)
+      -lp<progname>  set the program name used for logging
+      -lu            use microseconds for logging timestamps
+      -lh            add hostname to log messages
+      -v     verbose data traffic, text
+      -x     verbose data traffic, hexadecimal
+      -b<size_t>     set data buffer size (8192)
+      -s     sloppy (continue on error)
+      -t<timeout>    wait seconds before closing second channel
+      -T<timeout>    total inactivity timeout in seconds
+      -u     unidirectional mode (left to right)
+      -U     unidirectional mode (right to left)
+      -g     do not check option groups
+      -L <lockfile>  try to obtain lock, or fail
+      -W <lockfile>  try to obtain lock, or wait
+      -4     prefer IPv4 if version is not explicitly specified
+      -6     prefer IPv6 if version is not explicitly specified
+   bi-address:
+      pipe[,<opts>]	groups=FD,FIFO
+      <single-address>!!<single-address>
+      <single-address>
+   single-address:
+      <address-head>[,<opts>]
+   address-head:
+      abstract-client:<filename>	groups=FD,SOCKET,RETRY,UNIX
+      abstract-connect:<filename>	groups=FD,SOCKET,RETRY,UNIX
+      abstract-listen:<filename>	groups=FD,SOCKET,LISTEN,CHILD,RETRY,UNIX
+      abstract-recv:<filename>	groups=FD,SOCKET,RETRY,UNIX
+      abstract-recvfrom:<filename>	groups=FD,SOCKET,CHILD,RETRY,UNIX
+      abstract-sendto:<filename>	groups=FD,SOCKET,RETRY,UNIX
+      create:<filename>	groups=FD,REG,NAMED
+      exec:<command-line>	groups=FD,FIFO,SOCKET,EXEC,FORK,TERMIOS,PTY,PARENT,UNIX
+      fd:<num>	groups=FD,FIFO,CHR,BLK,REG,SOCKET,TERMIOS,UNIX,IP4,IP6,UDP,TCP,SCTP
+      gopen:<filename>	groups=FD,FIFO,CHR,BLK,REG,SOCKET,NAMED,OPEN,TERMIOS,UNIX
+      interface:<interface>	groups=FD,SOCKET
+      ip-datagram:<host>:<protocol>	groups=FD,SOCKET,RANGE,IP4,IP6
+      ip-recv:<protocol>	groups=FD,SOCKET,RANGE,IP4,IP6
+      ip-recvfrom:<protocol>	groups=FD,SOCKET,CHILD,RANGE,IP4,IP6
+      ip-sendto:<host>:<protocol>	groups=FD,SOCKET,IP4,IP6
+      ip4-datagram:<host>:<protocol>	groups=FD,SOCKET,RANGE,IP4
+      ip4-recv:<protocol>	groups=FD,SOCKET,RANGE,IP4
+      ip4-recvfrom:<protocol>	groups=FD,SOCKET,CHILD,RANGE,IP4
+      ip4-sendto:<host>:<protocol>	groups=FD,SOCKET,IP4
+      ip6-datagram:<host>:<protocol>	groups=FD,SOCKET,RANGE,IP6
+      ip6-recv:<protocol>	groups=FD,SOCKET,RANGE,IP6
+      ip6-recvfrom:<protocol>	groups=FD,SOCKET,CHILD,RANGE,IP6
+      ip6-sendto:<host>:<protocol>	groups=FD,SOCKET,IP6
+      open:<filename>	groups=FD,FIFO,CHR,BLK,REG,NAMED,OPEN,TERMIOS
+      openssl:<host>:<port>	groups=FD,SOCKET,CHILD,RETRY,IP4,IP6,TCP,OPENSSL
+      openssl-listen:<port>	groups=FD,SOCKET,LISTEN,CHILD,RETRY,RANGE,IP4,IP6,TCP,OPENSSL
+      pipe:<filename>	groups=FD,FIFO,NAMED,OPEN
+      proxy:<proxy-server>:<host>:<port>	groups=FD,SOCKET,CHILD,RETRY,IP4,IP6,TCP,HTTP
+      pty	groups=FD,NAMED,TERMIOS,PTY
+      sctp-connect:<host>:<port>	groups=FD,SOCKET,CHILD,RETRY,IP4,IP6,SCTP
+      sctp-listen:<port>	groups=FD,SOCKET,LISTEN,CHILD,RETRY,RANGE,IP4,IP6,SCTP
+      sctp4-connect:<host>:<port>	groups=FD,SOCKET,CHILD,RETRY,IP4,SCTP
+      sctp4-listen:<port>	groups=FD,SOCKET,LISTEN,CHILD,RETRY,RANGE,IP4,SCTP
+      sctp6-connect:<host>:<port>	groups=FD,SOCKET,CHILD,RETRY,IP6,SCTP
+      sctp6-listen:<port>	groups=FD,SOCKET,LISTEN,CHILD,RETRY,RANGE,IP6,SCTP
+      socket-connect:<domain>:<protocol>:<remote-address>	groups=FD,SOCKET,CHILD,RETRY
+      socket-datagram:<domain>:<type>:<protocol>:<remote-address>	groups=FD,SOCKET,RANGE
+      socket-listen:<domain>:<protocol>:<local-address>	groups=FD,SOCKET,LISTEN,CHILD,RETRY,RANGE
+      socket-recv:<domain>:<type>:<protocol>:<local-address>	groups=FD,SOCKET,RANGE
+      socket-recvfrom:<domain>:<type>:<protocol>:<local-address>	groups=FD,SOCKET,CHILD,RANGE
+      socket-sendto:<domain>:<type>:<protocol>:<remote-address>	groups=FD,SOCKET
+      socks4:<socks-server>:<host>:<port>	groups=FD,SOCKET,CHILD,RETRY,IP4,IP6,TCP,SOCKS4
+      socks4a:<socks-server>:<host>:<port>	groups=FD,SOCKET,CHILD,RETRY,IP4,IP6,TCP,SOCKS4
+      stderr	groups=FD,FIFO,CHR,BLK,REG,SOCKET,TERMIOS,UNIX,IP4,IP6,UDP,TCP,SCTP
+      stdin	groups=FD,FIFO,CHR,BLK,REG,SOCKET,TERMIOS,UNIX,IP4,IP6,UDP,TCP,SCTP
+      stdio	groups=FD,FIFO,CHR,BLK,REG,SOCKET,TERMIOS,UNIX,IP4,IP6,UDP,TCP,SCTP
+      stdout	groups=FD,FIFO,CHR,BLK,REG,SOCKET,TERMIOS,UNIX,IP4,IP6,UDP,TCP,SCTP
+      system:<shell-command>	groups=FD,FIFO,SOCKET,EXEC,FORK,TERMIOS,PTY,PARENT,UNIX
+      tcp-connect:<host>:<port>	groups=FD,SOCKET,CHILD,RETRY,IP4,IP6,TCP
+      tcp-listen:<port>	groups=FD,SOCKET,LISTEN,CHILD,RETRY,RANGE,IP4,IP6,TCP
+      tcp4-connect:<host>:<port>	groups=FD,SOCKET,CHILD,RETRY,IP4,TCP
+      tcp4-listen:<port>	groups=FD,SOCKET,LISTEN,CHILD,RETRY,RANGE,IP4,TCP
+      tcp6-connect:<host>:<port>	groups=FD,SOCKET,CHILD,RETRY,IP6,TCP
+      tcp6-listen:<port>	groups=FD,SOCKET,LISTEN,CHILD,RETRY,RANGE,IP6,TCP
+      tun[:<ip-addr>/<bits>]	groups=FD,CHR,NAMED,OPEN,INTERFACE
+      udp-connect:<host>:<port>	groups=FD,SOCKET,IP4,IP6,UDP
+      udp-datagram:<host>:<port>	groups=FD,SOCKET,RANGE,IP4,IP6,UDP
+      udp-listen:<port>	groups=FD,SOCKET,LISTEN,CHILD,RANGE,IP4,IP6,UDP
+      udp-recv:<port>	groups=FD,SOCKET,RANGE,IP4,IP6,UDP
+      udp-recvfrom:<port>	groups=FD,SOCKET,CHILD,RANGE,IP4,IP6,UDP
+      udp-sendto:<host>:<port>	groups=FD,SOCKET,IP4,IP6,UDP
+      udp4-connect:<host>:<port>	groups=FD,SOCKET,IP4,UDP
+      udp4-datagram:<remote-address>:<port>	groups=FD,SOCKET,RANGE,IP4,UDP
+      udp4-listen:<port>	groups=FD,SOCKET,LISTEN,CHILD,RANGE,IP4,UDP
+      udp4-recv:<port>	groups=FD,SOCKET,RANGE,IP4,UDP
+      udp4-recvfrom:<host>:<port>	groups=FD,SOCKET,CHILD,RANGE,IP4,UDP
+      udp4-sendto:<host>:<port>	groups=FD,SOCKET,IP4,UDP
+      udp6-connect:<host>:<port>	groups=FD,SOCKET,IP6,UDP
+      udp6-datagram:<host>:<port>	groups=FD,SOCKET,RANGE,IP6,UDP
+      udp6-listen:<port>	groups=FD,SOCKET,LISTEN,CHILD,RANGE,IP6,UDP
+      udp6-recv:<port>	groups=FD,SOCKET,RANGE,IP6,UDP
+      udp6-recvfrom:<port>	groups=FD,SOCKET,CHILD,RANGE,IP6,UDP
+      udp6-sendto:<host>:<port>	groups=FD,SOCKET,IP6,UDP
+      unix-client:<filename>	groups=FD,SOCKET,NAMED,RETRY,UNIX
+      unix-connect:<filename>	groups=FD,SOCKET,NAMED,RETRY,UNIX
+      unix-listen:<filename>	groups=FD,SOCKET,NAMED,LISTEN,CHILD,RETRY,UNIX
+      unix-recv:<filename>	groups=FD,SOCKET,NAMED,RETRY,UNIX
+      unix-recvfrom:<filename>	groups=FD,SOCKET,NAMED,CHILD,RETRY,UNIX
+      unix-sendto:<filename>	groups=FD,SOCKET,NAMED,RETRY,UNIX
+```

--- a/test/blackjack/entrypoint.sh
+++ b/test/blackjack/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+socat -v -T1 tcp4-l:1026,reuseaddr,fork "system:sed -ur -e \'s/^/no /\'"  &  # Careful quoting, NLB health check
+socat -v -T1 udp4-l:1025,reuseaddr,fork "system:sed -ur -e \'s/^/no /\'"     # Careful quoting


### PR DESCRIPTION
What does this do ?
* Adds support for `UDP` service configs using an ELBv2 NLB
  * `udp_interface` key - mutually exclusive with `http_interface`
  * consider also supporting `tcp_interface` with a follow task
    * this could use ECS dynamic host ports, test with `nginx` deployment

## Limitations
* [Cannot use dynamic host ports](https://github.com/aws/containers-roadmap/issues/85)
```
The task definition is configured to use a dynamic host port, but the target group with
 targetGroupArn ... has a health check port specified. 
(Service: AmazonECS; Status Code: 400; Error Code: InvalidParameterException; Request ID: ...)
```

## Ports
* NLB Listener Port
* Target Group Port
* Host Port
* Container Port
```
Container Port + Target Group Port => should be the same.
NLB Listener Port                  => what clients see
Host Port                          => ideally dynamic
```

## Config
```json
{
    "services": {
        "Blackjack": {
            "command": null,
            "udp_interface": {
                "container_port": 1025,
                "internal": false,
                "restrict_access_to": [
                    "0.0.0.0/0"
                ]
            },
            "memory_reservation": 100
        }
    }
}
```

## Usage
```bash
cloudlift$ cloudlift create_environment -e staging
cloudlift$ (cd test/blackjack; cloudlift create_service -e staging)
cloudlift$ (cd test/blackjack; cloudlift deploy_service -e staging)
```

## Changes
- [x] [cloudlift/deployment/service_template_generator.py](https://github.com/cicdenv/cloudlift/blob/fvogt/NLB-udp/cloudlift/deployment/service_template_generator.py)
  - [x] `interface spec: nlb, lb, service_listener, nlb_sg = self._add_nlb(cd, service_name, config, launch_type)`
  - [x] `NLB resoruce: _add_nlb(self, cd, service_name, config, launch_type)`
  - [x] health checks
  - [x] `SecurityGroupIngress=self._generate_nlb_security_group_ingress(config)`
  - [x] self._add_nlb_alarms(service_name, nlb)`
  - [x] `cluster::SecurityGroupAlb` - environment level item
    - [x] for NLB tcp/udp ports must be exposed on the ECS cluster SG
  - [x] NLB health checks only support TCP, HTTP, HTTPS
  - [*] Support dynamic host ports
    - Not supported - [ECS - Add UDP_TCP protocol for container portMapping in the task definition #850](https://github.com/aws/containers-roadmap/issues/850)
- [*] tests
  - [x] sample app - udp echo w/small text transformation w/Dockerfile
  - `echo "deal" | socat - udp:<nlb-dns-name>:1025`
  - https://github.com/cicdenv/cloudlift/wiki/tests-issues

NOTES: https://github.com/cicdenv/cloudlift/wiki

## Links
* https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html
  * TCP_UDP - protocol setting
* [[ECS] [request]: Add UDP_TCP protocol for container portMapping in the task definition #850](https://github.com/aws/containers-roadmap/issues/850)
* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/troubleshoot-service-load-balancers.html

## Reference
* https://github.com/cloudtools/troposphere
  * https://troposphere.readthedocs.io/en/latest/
* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/register-multiple-targetgroups.html
* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-network-load-balancer.html
* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/register-multiple-targetgroups.html
* https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-loadbalancers.html
