### PR TITLE
recommended python3.6.9 (compatibility issues with newer python versi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ in AWS.
 ```sh
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py | python get-pip.py
 ```
+- It's recommended that you use python3.6. (compatibility issues with newer python versions)You can do so easily using pyenv
+```
+brew install pyenv
+pyenv install 3.6.9
+pyenv pyenv global 3.6.9
+```
+
+- PATH changes
+```
+export PATH="$HOME/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+```
 
 ### 2. Download and Install cloudlift
 


### PR DESCRIPTION
There was a pickling error with python3.8.5

`_pickle.PicklingError: Can't pickle <class 'botocore.client.ECS'>: attribute lookup ECS on botocore.client failed`

Recommended python3.6.9 