### PR TITLE
Fix template length limit

### DIFF
--- a/cloudlift/deployment/changesets.py
+++ b/cloudlift/deployment/changesets.py
@@ -6,8 +6,7 @@ import click
 
 from cloudlift.config.logging import log, log_bold, log_err
 
-
-def create_change_set(client, service_template_body, stack_name,
+def create_change_set(client, service_template_body, template_source, stack_name,
                       key_name, environment):
     change_set_parameters = [
         {'ParameterKey': 'Environment', 'ParameterValue': environment}
@@ -17,14 +16,24 @@ def create_change_set(client, service_template_body, stack_name,
             'ParameterKey': 'KeyPair',
             'ParameterValue': key_name
         })
-    create_change_set_res = client.create_change_set(
-        StackName=stack_name,
-        ChangeSetName="cg"+uuid.uuid4().hex,
-        TemplateBody=service_template_body,
-        Parameters=change_set_parameters,
-        Capabilities=['CAPABILITY_NAMED_IAM'],
-        ChangeSetType='UPDATE'
-    )
+    if template_source == 'TemplateBody':
+        create_change_set_res = client.create_change_set(
+            StackName=stack_name,
+            ChangeSetName="cg"+uuid.uuid4().hex,
+            TemplateBody=service_template_body,
+            Parameters=change_set_parameters,
+            Capabilities=['CAPABILITY_NAMED_IAM'],
+            ChangeSetType='UPDATE'
+        )
+    elif template_source == 'TemplateURL':
+        create_change_set_res = client.create_change_set(
+            StackName=stack_name,
+            ChangeSetName="cg"+uuid.uuid4().hex,
+            TemplateURL=service_template_body,
+            Parameters=change_set_parameters,
+            Capabilities=['CAPABILITY_NAMED_IAM'],
+            ChangeSetType='UPDATE'
+        )
     log("Changeset creation initiated. Checking the progress...")
     change_set = client.describe_change_set(
         ChangeSetName=create_change_set_res['Id']

--- a/cloudlift/deployment/service_creator.py
+++ b/cloudlift/deployment/service_creator.py
@@ -28,12 +28,26 @@ class ServiceCreator(object):
         self.environment = environment
         self.stack_name = get_service_stack_name(environment, name)
         self.client = get_client_for('cloudformation', self.environment)
+        self.s3client = get_client_for('s3', self.environment)
+        self.bucket_name = 'simpl-shoan-test'
         self.environment_stack = self._get_environment_stack()
         self.existing_events = get_stack_events(self.client, self.stack_name)
         self.service_configuration = ServiceConfiguration(
             self.name,
             self.environment
         )
+
+    def delete_template(self, key):
+        '''
+            Delete CloudFormation Template stored in S3 bucket
+        '''
+        try:
+            self.s3client.delete_object(
+                Bucket=self.bucket_name,
+                Key=key,
+            )
+        except ClientError as boto_client_error:
+            raise boto_client_error
 
     def create(self):
         '''
@@ -47,22 +61,36 @@ class ServiceCreator(object):
             self.service_configuration,
             self.environment_stack
         )
-        service_template_body = template_generator.generate_service()
+        service_template_body, template_source, key = template_generator.generate_service()
 
         try:
-            self.client.create_stack(
-                StackName=self.stack_name,
-                TemplateBody=service_template_body,
-                Parameters=[{
-                    'ParameterKey': 'Environment',
-                    'ParameterValue': self.environment,
-                }],
-                OnFailure='DO_NOTHING',
-                Capabilities=['CAPABILITY_NAMED_IAM'],
-            )
+            if template_source == 'TemplateBody':
+                self.client.create_stack(
+                    StackName=self.stack_name,
+                    TemplateBody=service_template_body,
+                    Parameters=[{
+                        'ParameterKey': 'Environment',
+                        'ParameterValue': self.environment,
+                    }],
+                    OnFailure='DO_NOTHING',
+                    Capabilities=['CAPABILITY_NAMED_IAM'],
+                )
+            elif template_source == 'TemplateURL':
+                self.client.create_stack(
+                    StackName=self.stack_name,
+                    TemplateURL=service_template_body,
+                    Parameters=[{
+                        'ParameterKey': 'Environment',
+                        'ParameterValue': self.environment,
+                    }],
+                    OnFailure='DO_NOTHING',
+                    Capabilities=['CAPABILITY_NAMED_IAM'],
+                )
             log_bold("Submitted to cloudformation. Checking progress...")
+            self.delete_template(key)
             self._print_progress()
         except ClientError as boto_client_error:
+            self.delete_template(key)
             error_code = boto_client_error.response['Error']['Code']
             if error_code == 'AlreadyExistsException':
                 raise UnrecoverableException("Stack " + self.stack_name + " already exists.")
@@ -82,23 +110,27 @@ class ServiceCreator(object):
                 self.service_configuration,
                 self.environment_stack
             )
-            service_template_body = template_generator.generate_service()
+            service_template_body, template_source, key = template_generator.generate_service()
             change_set = create_change_set(
                 self.client,
                 service_template_body,
+                template_source,
                 self.stack_name,
                 "",
                 self.environment
             )
             if change_set is None:
+                self.delete_template(key)
                 return
             self.service_configuration.update_cloudlift_version()
             log_bold("Executing changeset. Checking progress...")
             self.client.execute_change_set(
                 ChangeSetName=change_set['ChangeSetId']
             )
+            self.delete_template(key)
             self._print_progress()
         except ClientError as exc:
+            self.delete_template(key)
             if "No updates are to be performed." in str(exc):
                 log_err("No updates are to be performed")
             else:

--- a/cloudlift/deployment/service_creator.py
+++ b/cloudlift/deployment/service_creator.py
@@ -29,7 +29,7 @@ class ServiceCreator(object):
         self.stack_name = get_service_stack_name(environment, name)
         self.client = get_client_for('cloudformation', self.environment)
         self.s3client = get_client_for('s3', self.environment)
-        self.bucket_name = 'simpl-shoan-test'
+        self.bucket_name = 'cloudlift-service-template'
         self.environment_stack = self._get_environment_stack()
         self.existing_events = get_stack_events(self.client, self.stack_name)
         self.service_configuration = ServiceConfiguration(

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -89,7 +89,7 @@ class ServiceTemplateGenerator(TemplateGenerator):
             except ClientError as boto_client_error:
                 error_code = boto_client_error.response['Error']['Code']
                 if error_code == 'AccessDenied':
-                    raise UnrecoverableException("Unable to store cloudlift service template in S3 at "+ self.bucket_name)
+                    raise UnrecoverableException("Unable to store cloudlift service template in S3 bucket at "+ str(self.bucket_name))
                 else:
                     raise boto_client_error
         else:

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -89,7 +89,7 @@ class ServiceTemplateGenerator(TemplateGenerator):
             except ClientError as boto_client_error:
                 error_code = boto_client_error.response['Error']['Code']
                 if error_code == 'AccessDenied':
-                    raise UnrecoverableException("Access Denied")
+                    raise UnrecoverableException("Unable to store cloudlift service template in S3 at "+ self.bucket_name)
                 else:
                     raise boto_client_error
         else:

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -60,7 +60,7 @@ class ServiceTemplateGenerator(TemplateGenerator):
         self.environment_stack = environment_stack
         self.current_version = ServiceInformationFetcher(
             self.application_name, self.env).get_current_version()
-        self.bucket_name = 'simpl-shoan-test'
+        self.bucket_name = 'cloudlift-service-template'
         self.environment = service_configuration.environment
         self.client = get_client_for('s3', self.environment)
 
@@ -77,7 +77,7 @@ class ServiceTemplateGenerator(TemplateGenerator):
         
         letters = string.ascii_lowercase
         key = ''.join(random.choice(letters) for i in range(20)) + '.yml'
-        if len(to_yaml(self.template.to_json())) < 51000:
+        if len(to_yaml(self.template.to_json())) > 51000:
             try:
                 self.client.put_object(
                     Body=to_yaml(self.template.to_json()),

--- a/cloudlift/version/__init__.py
+++ b/cloudlift/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.4.5'
+VERSION = '1.4.6'


### PR DESCRIPTION
Some users were hitting Template size limit .i.e 51200 bytes when having multiple services in a single template. 
This fix will let them use Template s3 URL whenever the template size exceeds 51000 bytes. 