### PR TITLE
Added capability to send logs to /dev/null

### DIFF
--- a/cloudlift/config/service_configuration.py
+++ b/cloudlift/config/service_configuration.py
@@ -223,6 +223,9 @@ class ServiceConfiguration(object):
                         {"type": "string"},
                         {"type": "null"}
                     ]
+                },
+                "no_logs": {
+                    "type": "boolean"
                 }
             },
             "required": ["memory_reservation", "command"]

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -193,7 +193,6 @@ service is down',
             "Name": service_name + "Container",
             "Image": self.ecr_image_uri + ':' + self.current_version,
             "Essential": 'true',
-            "LogConfiguration": self._gen_log_config(service_name),
             "Memory": int(config['memory_reservation']) + -(-(int(config['memory_reservation']) * 50 )//100), # Celling the value 
             "MemoryReservation": int(config['memory_reservation']),
             "Cpu": 0
@@ -207,6 +206,13 @@ service is down',
                     )
                 )
             ]
+        if 'no_logs' not in config:
+            container_definition_arguments['LogConfiguration'] = self._gen_log_config(service_name)
+
+        if 'no_logs' in config:
+            if not config['no_logs']:
+                container_definition_arguments['LogConfiguration'] = self._gen_log_config(service_name)
+
 
         if config['command'] is not None:
             container_definition_arguments['Command'] = [config['command']]


### PR DESCRIPTION
Add a new var in service config "no_logs" type boolean. When the value set to the `true`, deployed service will be default docker log as logging driver. 

After testing if user want to enable log streaming to cloudwatch,  change "no_logs" value to false. 

Note: The variable is option. Default behaviour is the stream logs to cw. 

Testing process:

- Deployed test-service-krishna with cloudlift version 1.5.4. 
- Build the code locally in virtual environment. 
- Update service config add no_logs to true. 
- Update service again to add cw logs by update no_logs value to false






