### PR TITLE
Migrated environment variable to secret inside ECS Task defination 

### DIFF
--- a/cloudlift/config/parameter_store.py
+++ b/cloudlift/config/parameter_store.py
@@ -20,13 +20,14 @@ class ParameterStore(object):
         self.client = get_client_for('ssm', environment)
 
     def get_existing_config_as_string(self):
-        environment_configs = self.get_existing_config()
+        environment_configs, environment_configs_path = self.get_existing_config()
         return '\n'.join('{}={}'.format(key, val) for key, val in sorted(
             environment_configs.items()
         ))
 
     def get_existing_config(self):
         environment_configs = {}
+        environment_configs_path = {}
         next_token = None
         while True:
             if next_token:
@@ -47,12 +48,12 @@ class ParameterStore(object):
             for parameter in response['Parameters']:
                 parameter_name = parameter['Name'].split(self.path_prefix)[1]
                 environment_configs[parameter_name] = parameter['Value']
-
+                environment_configs_path[parameter_name] = parameter['ARN']
             try:
                 next_token = response['NextToken']
             except KeyError:
                 break
-        return environment_configs
+        return environment_configs, environment_configs_path
 
     def set_config(self, differences):
         self._validate_changes(differences)

--- a/cloudlift/deployment/ecs.py
+++ b/cloudlift/deployment/ecs.py
@@ -62,7 +62,6 @@ class EcsClient(object):
         fargate_td = {}
         if 'FARGATE' in requires_compatibilities:
             fargate_td = {
-                'executionRoleArn': execution_role_arn or u'',
                 'requiresCompatibilities': requires_compatibilities or [],
                 'cpu': cpu,
                 'memory': memory,
@@ -71,6 +70,7 @@ class EcsClient(object):
             family=family,
             containerDefinitions=containers,
             volumes=volumes,
+            executionRoleArn=execution_role_arn,
             taskRoleArn=role_arn or u'',
             networkMode=network_mode,
             **fargate_td
@@ -304,8 +304,8 @@ class EcsTaskDefinition(dict):
 
     def apply_container_environment(self, container, new_environment):
         old_environment = {
-            env['name']: env['value'] for env in container.get(
-                'environment',
+            env['name']: env['valueFrom'] for env in container.get(
+                'secrets',
                 {}
             )
         }
@@ -313,16 +313,16 @@ class EcsTaskDefinition(dict):
 
         diff = EcsTaskDefinitionDiff(
             container[u'name'],
-            u'environment',
+            u'secrets',
             merged_environment,
             old_environment
         )
         self._diff.append(diff)
 
-        container[u'environment'] = [
+        container[u'secrets'] = [
             {
                 "name": e,
-                "value": merged_environment[e]
+                "valueFrom": merged_environment[e]
             } for e in merged_environment
         ]
 
@@ -423,7 +423,6 @@ class EcsAction(object):
         if task_definition.requires_compatibilities and 'FARGATE' in task_definition.requires_compatibilities:
 
             fargate_td = {
-                'execution_role_arn': task_definition.execution_role_arn or u'',
                 'requires_compatibilities': task_definition.requires_compatibilities or [],
                 'cpu' : task_definition.cpu or u'',
                 'memory' : task_definition.memory or u'',
@@ -434,6 +433,7 @@ class EcsAction(object):
             containers=task_definition.containers,
             volumes=task_definition.volumes,
             role_arn=task_definition.role_arn,
+            execution_role_arn=task_definition.execution_role_arn,
             network_mode=task_definition.network_mode or u'bridge',
             **fargate_td
         )

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -15,7 +15,7 @@ from troposphere import GetAtt, Output, Parameter, Ref, Sub, ImportValue, Tags
 from troposphere.cloudwatch import Alarm, MetricDimension
 from troposphere.ec2 import SecurityGroup
 from troposphere.ecs import (AwsvpcConfiguration, ContainerDefinition,
-                             DeploymentConfiguration, Environment, MountPoint,
+                             DeploymentConfiguration, Secret, MountPoint,
                              LoadBalancer, LogConfiguration, Volume, EFSVolumeConfiguration,
                              NetworkConfiguration, PlacementStrategy,
                              PortMapping, Service, TaskDefinition, ServiceRegistry)
@@ -187,8 +187,8 @@ service is down',
             self.env_sample_file_path
         )
         container_definition_arguments = {
-            "Environment": [
-                Environment(Name=k, Value=v) for (k, v) in env_config
+            "Secrets": [
+                Secret(Name=k, ValueFrom=v) for (k, v) in env_config
             ],
             "Name": service_name + "Container",
             "Image": self.ecr_image_uri + ':' + self.current_version,
@@ -258,6 +258,7 @@ service is down',
             service_name + "TaskDefinition",
             Family=service_name + "Family",
             ContainerDefinitions=[cd],
+            ExecutionRoleArn=boto3.resource('iam').Role('ecsTaskExecutionRole').arn,
             TaskRoleArn=Ref(task_role),
             Tags=Tags(Team=self.team_name, environment=self.env),
             **launch_type_td

--- a/cloudlift/deployment/task_definition_creator.py
+++ b/cloudlift/deployment/task_definition_creator.py
@@ -45,10 +45,10 @@ class TaskDefinitionCreator:
         log_bold("Creating task definition\n")
         env_config = build_config(self.environment, self.name, self.env_sample_file)
         container_definition_arguments = {
-            "environment": [
+            "secrets": [
                 {
                     "name": k,
-                    "value": v
+                    "valueFrom": v
                 } for (k, v) in env_config
             ],
             "name": pascalcase(self.name) + "Container",

--- a/cloudlift/version/__init__.py
+++ b/cloudlift/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.4'
+VERSION = '1.5.5'


### PR DESCRIPTION
Right now we are using Environment variable inside Task Definition and because of this anyone who has ECS console access can see the values. 
<img width="800" alt="Screenshot 2023-01-24 at 1 30 34 PM" src="https://user-images.githubusercontent.com/18118587/214240133-a6c816bd-c39d-411b-8f82-2fd0f66b0c71.png">


After this PR ECS will use SSM Parameter ARN and not the value. 
<img width="800" alt="Screenshot 2023-01-24 at 1 30 44 PM" src="https://user-images.githubusercontent.com/18118587/214240301-1e32fc5f-7ce2-4f3c-8ab7-2c9043737768.png">

ECS will get the value from SSM and set that as ENV value in backgroud.