### PR TITLE
fix(update_service): fixes TaskDefinition inactive exception

### DIFF
--- a/cloudlift/deployment/service_information_fetcher.py
+++ b/cloudlift/deployment/service_information_fetcher.py
@@ -43,9 +43,9 @@ class ServiceInformationFetcher(object):
             self.ecs_service_names = []
             log_warning("Could not determine services.")
 
-    def get_current_version(self):
+    def get_current_version(self, skip_master_reset=False):
         commit_sha = self._fetch_current_task_definition_tag()
-        if commit_sha is None or commit_sha == 'dirty':
+        if commit_sha is None or commit_sha == 'dirty' and not skip_master_reset:
             log_warning("Currently deployed tag could not be found or is dirty,\
 resetting to master")
             commit_sha = "master"

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -309,7 +309,7 @@ service is down',
             ContainerDefinitions=[cd],
             ExecutionRoleArn=boto3.resource('iam').Role('ecsTaskExecutionRole').arn,
             TaskRoleArn=Ref(task_role),
-            Tags=Tags(Team=self.team_name, environment=self.env),
+            Tags=Tags(Team=self.team_name, environment=self.env, task_definition_source="cloudformation"),
             **launch_type_td
 
         )


### PR DESCRIPTION
- Added a new tag in task definition "task_definition_source" to identify if task definition was created with cloudformation or with boto
- Included a preflight step to verify whether the existing deployment is dirty, and if it is, whether an image with the tag 'master' is available on ECR.