### PR TITLE
fix: remove placement constraints in fargate launch type

### DIFF
--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -227,24 +227,24 @@ service is down',
             "Cpu": 0
         }
         placement_constraint = {}
-        for key in self.environment_stack["Outputs"]:
-            if key["OutputKey"] == 'ECSClusterDefaultInstanceLifecycle':
-                spot_deployment = False if ImportValue("{self.env}ECSClusterDefaultInstanceLifecycle".format(**locals())) == 'ondemand' else True
-                if 'fargate' not in config:
+        if 'fargate' not in config:
+            for key in self.environment_stack["Outputs"]:
+                if key["OutputKey"] == 'ECSClusterDefaultInstanceLifecycle':
+                    spot_deployment = False if ImportValue("{self.env}ECSClusterDefaultInstanceLifecycle".format(**locals())) == 'ondemand' else True
                     placement_constraint = {
                         "PlacementConstraints": [PlacementConstraint(
                             Type='memberOf',
                             Expression='attribute:deployment_type == spot' if spot_deployment else 'attribute:deployment_type == ondemand'
                         )],
                     }
-        if 'spot_deployment' in config and not 'fargate' in config:
-            spot_deployment = config["spot_deployment"]
-            placement_constraint = {
-                "PlacementConstraints" : [PlacementConstraint(
-                    Type='memberOf',
-                    Expression='attribute:deployment_type == spot' if spot_deployment else 'attribute:deployment_type == ondemand'
-                )],
-            }
+            if 'spot_deployment' in config:
+                spot_deployment = config["spot_deployment"]
+                placement_constraint = {
+                    "PlacementConstraints" : [PlacementConstraint(
+                        Type='memberOf',
+                        Expression='attribute:deployment_type == spot' if spot_deployment else 'attribute:deployment_type == ondemand'
+                    )],
+                }
 
         if 'http_interface' in config:
             container_definition_arguments['PortMappings'] = [

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -230,13 +230,14 @@ service is down',
         for key in self.environment_stack["Outputs"]:
             if key["OutputKey"] == 'ECSClusterDefaultInstanceLifecycle':
                 spot_deployment = False if ImportValue("{self.env}ECSClusterDefaultInstanceLifecycle".format(**locals())) == 'ondemand' else True
-                placement_constraint = {
-                    "PlacementConstraints": [PlacementConstraint(
-                        Type='memberOf',
-                        Expression='attribute:deployment_type == spot' if spot_deployment else 'attribute:deployment_type == ondemand'
-                    )],
-                }
-        if 'spot_deployment' in config:
+                if 'fargate' not in config:
+                    placement_constraint = {
+                        "PlacementConstraints": [PlacementConstraint(
+                            Type='memberOf',
+                            Expression='attribute:deployment_type == spot' if spot_deployment else 'attribute:deployment_type == ondemand'
+                        )],
+                    }
+        if 'spot_deployment' in config and not 'fargate' in config:
             spot_deployment = config["spot_deployment"]
             placement_constraint = {
                 "PlacementConstraints" : [PlacementConstraint(


### PR DESCRIPTION
This commit fixes `Placement constraints are not supported` error in fagate launch types. The commit removes placement constraints in fargate launch type.

## More Context
If we create a service or try to update a service with Fargate launch type, `ServiceTemplateGenerator`  creates a placement constraint, which Fargate doesn't support. 

https://github.com/GetSimpl/cloudlift/blob/42ac228582900f50271c4a4ba23d93c1eb777979/cloudlift/deployment/service_template_generator.py#L422

This throws an error: `Resource handler returned message: "Invalid request provided: CreateService error: Placement constraints are not supported with FARGATE launch type. (Service: AmazonECS; Status Code: 400; Error Code: InvalidParameterException)`

### How to Reproduce
Here's an example service configuration to reproduce the error
```json
{
      "notifications_arn": "notifications_arn",
      "services": {
            "Service": {
                  "fargate": {
                        "cpu": 512,
                        "memory": 1024
                  },
                  "memory_reservation": 500,
                  "command": null,
                  "spot_deployment": false, // this key is causing the issue
                  "http_interface": {
                        "restrict_access_to": [
                              "0.0.0.0/0"
                        ],
                        "container_port": 80,
                        "internal": false,
                        "health_check_path": "/"
                  }
            }
      }
}
```

