### PR TITLE
Disabled IMDSv1

### DIFF
--- a/cloudlift/deployment/cluster_template_generator.py
+++ b/cloudlift/deployment/cluster_template_generator.py
@@ -12,7 +12,8 @@ from troposphere.cloudwatch import Alarm, MetricDimension
 from troposphere.ec2 import (VPC, InternetGateway, NatGateway, Route,
                              RouteTable, SecurityGroup, Subnet,
                              SubnetRouteTableAssociation, VPCGatewayAttachment,SecurityGroupIngress,
-                             LaunchTemplateData, LaunchTemplate, IamInstanceProfile, LaunchTemplateBlockDeviceMapping, EBSBlockDevice)
+                             LaunchTemplateData, LaunchTemplate, IamInstanceProfile, LaunchTemplateBlockDeviceMapping,
+                             EBSBlockDevice, MetadataOptions)
 from troposphere.ecs import Cluster
 from troposphere.elasticache import SubnetGroup as ElastiCacheSubnetGroup
 from troposphere.iam import InstanceProfile, Role
@@ -565,6 +566,7 @@ class ClusterTemplateGenerator(TemplateGenerator):
                 SecurityGroupIds=[GetAtt(self.sg_hosts, 'GroupId')],
                 ImageId=FindInMap("AWSRegionToAMI", Ref("AWS::Region"), "AMI"),
                 KeyName=Ref(self.key_pair),
+                MetadataOptions=MetadataOptions(HttpTokens="required"),
                 BlockDeviceMappings=[
                     LaunchTemplateBlockDeviceMapping(
                         DeviceName="/dev/xvda",

--- a/cloudlift/version/__init__.py
+++ b/cloudlift/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '2.0.4'
+VERSION = '2.0.5'

--- a/cloudlift/version/__init__.py
+++ b/cloudlift/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '2.0.5'
+VERSION = '2.0.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-boto3
-awscli
+boto3==1.34.111  
+awscli==1.32.111  
 certifi==2017.7.27.1
 cfn-flip==1.0.3
 chardet==3.0.4
@@ -21,4 +21,4 @@ stringcase==1.0.6
 terminaltables==3.1.0
 troposphere==4.5.2
 awacs==2.4.0
-botocore
+botocore==1.34.111  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-boto3==1.24.2
-awscli==1.25.2
+boto3
+awscli
 certifi==2017.7.27.1
 cfn-flip==1.0.3
 chardet==3.0.4
@@ -19,6 +19,6 @@ requests>=2.20.0
 six==1.10.0
 stringcase==1.0.6
 terminaltables==3.1.0
-troposphere==4.0.0
-awacs==2.0.1
-botocore==1.27.2
+troposphere==4.5.2
+awacs==2.4.0
+botocore


### PR DESCRIPTION
IMDSv1 is insecure and allows for metadata leakage through SSRF.

Troposphere and other packages were upgraded to accomodate this.