### PR TITLE
Fix/service placement default to spot

### DIFF
--- a/cloudlift/config/environment_configuration.py
+++ b/cloudlift/config/environment_configuration.py
@@ -302,7 +302,10 @@ class EnvironmentConfiguration(object):
                                 "key_name": {"type": "string"},
                                 "allocation_strategy": {"type": "string"},
                                 "spot_instance_pools": {"type": "integer"},
-                                "ecs_instance_default_lifecycle_type": {"type": "string"}
+                                "ecs_instance_default_lifecycle_type":  {
+                                    "type": "string",
+                                    "pattern": "^(spot|ondemand)$"
+                                }
                             },
                             "required": [
                                 "min_instances",

--- a/cloudlift/deployment/service_template_generator.py
+++ b/cloudlift/deployment/service_template_generator.py
@@ -234,7 +234,8 @@ service is down',
         if 'fargate' not in config:
             for key in self.environment_stack["Outputs"]:
                 if key["OutputKey"] == 'ECSClusterDefaultInstanceLifecycle':
-                    spot_deployment = False if ImportValue("{self.env}ECSClusterDefaultInstanceLifecycle".format(**locals())) == 'ondemand' else True
+                    instance_lifecycle = key["OutputValue"]
+                    spot_deployment = instance_lifecycle == 'spot'
                     placement_constraint = {
                         "PlacementConstraints": [PlacementConstraint(
                             Type='memberOf',

--- a/cloudlift/version/__init__.py
+++ b/cloudlift/version/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '2.0.5'
+VERSION = '2.0.6'


### PR DESCRIPTION
This fixes service always having spot as placement constraint if `spot_deployment` key doesn't exist on service configuration. 