### PR TITLE
fix(environment): update DNS configuration for proper container resolution

### DIFF
--- a/cloudlift/deployment/cluster_template_generator.py
+++ b/cloudlift/deployment/cluster_template_generator.py
@@ -495,10 +495,7 @@ class ClusterTemplateGenerator(TemplateGenerator):
                         content=Sub(
                             '\n'.join([
                                 '# Server Configuration',
-                                'listen-address=::1,127.0.0.1',
                                 'port=53',
-                                'bind-interfaces',
-                                'interface=lo',
                                 'user=dnsmasq',
                                 'group=dnsmasq',
                                 'pid-file=/var/run/dnsmasq.pid',
@@ -562,11 +559,17 @@ class ClusterTemplateGenerator(TemplateGenerator):
                         },
                         '07_add_localhost_nameserver': {
                             'command': textwrap.dedent(f"""
+                                        TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+                                        PRIMARY_IP=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)
+                                                       
                                         unlink /etc/resolv.conf
-                                        cat <<'EOF' | tee /etc/resolv.conf
+                                                       
+                                        cat <<EOF | tee /etc/resolv.conf
                                         nameserver 127.0.0.1
+                                        nameserver $PRIMARY_IP
+                                        nameserver 169.254.169.253
+                                        nameserver 8.8.8.8
                                         search {self.region}.compute.internal
-
                                         EOF
                                         """)
                         },


### PR DESCRIPTION
## fix(environment): update DNS configuration for proper container resolution

- Modify /etc/resolv.conf:
  - Replace loopback address with primary network interface IP
  - Add fallback nameservers (VPC DNS Resolver, Google DNS)
- Update dnsmasq to listen on all interfaces (0.0.0.0)

Resolves issue where Docker containers couldn't resolve private hosted zones due to fallback to Google DNS when loopback address was present. Ensures containers use host's dnsmasq for DNS resolution.

For details on Docker's DNS fallback behavior, see: https://github.com/moby/moby/blob/ddea6b0fa8f816377b59e3f7d7b3c32fef629022/libnetwork/internal/resolvconf/resolvconf.go#L40-L51